### PR TITLE
Make Darktable optional

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,11 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="curl gpg libdlib19 ffmpeg exiftool libheif1 darktable ca-certificates golang libdlib-dev libblas-dev liblapack-dev libjpeg-dev libheif-dev build-essential pkg-config autoconf automake libx265-dev libde265-dev libaom-dev"
+pkg_dependencies="curl gpg libdlib19 ffmpeg exiftool libheif1 ca-certificates golang libdlib-dev libblas-dev liblapack-dev libjpeg-dev libheif-dev build-essential pkg-config autoconf automake libx265-dev libde265-dev libaom-dev"
+
+if ! (apt-cache -q=0 show darktable |& grep ': No packages found' &>/dev/null); then
+	pkg_dependencies="$pkg_dependencies darktable"
+fi
 
 #=================================================
 # PERSONAL HELPERS


### PR DESCRIPTION
## Problem
- Not all platforms have Darktable available

## Solution
- Make it optional
## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.