### PR TITLE
Improve permissions: make /api and /share public

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Please send your pull request to the [testing branch](https://github.com/YunoHos
 
 To try the testing branch, please proceed like that.
 
-``` bash
+```bash
 sudo yunohost app install https://github.com/YunoHost-Apps/photoview_ynh/tree/testing --debug
 or
 sudo yunohost app upgrade photoview -u https://github.com/YunoHost-Apps/photoview_ynh/tree/testing --debug

--- a/README_fr.md
+++ b/README_fr.md
@@ -40,7 +40,7 @@ Merci de faire vos pull request sur la [branche testing](https://github.com/Yuno
 
 Pour essayer la branche testing, procédez comme suit.
 
-``` bash
+```bash
 sudo yunohost app install https://github.com/YunoHost-Apps/photoview_ynh/tree/testing --debug
 ou
 sudo yunohost app upgrade photoview -u https://github.com/YunoHost-Apps/photoview_ynh/tree/testing --debug

--- a/manifest.toml
+++ b/manifest.toml
@@ -70,7 +70,17 @@ ram.runtime = "200M"
 
     [resources.permissions]
     main.url = "/"
-
+    
+    api.url = "/api"
+    api.allow = "visitors"
+    api.auth_header = false
+    api.protect = true
+    
+    share.url = "/share"
+    share.allow = "visitors"
+    share.auth_header = false
+    share.protect = true
+    
     [resources.ports]
     main.default = 4001
 


### PR DESCRIPTION
My Photoview instance is rigged with:
- random-ish disconnections
- SSOed /share links
- CORS errors related with calls to the API being SSOed (notably, thumbnails not loading due to that)

Since, /api and /share paths are anyways meant to be public, let's add permissions to reflect that.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
